### PR TITLE
fix: players without displayed characters, abyss progress or world level appear

### DIFF
--- a/src/model/external/genshin/player-info/index.ts
+++ b/src/model/external/genshin/player-info/index.ts
@@ -6,13 +6,13 @@ export const playerInfoSchema = z.object({
   nickname: z.string(),
   level: z.number().min(1).max(60),
   signature: z.string().optional(),
-  worldLevel: z.number().min(0).max(8),
+  worldLevel: z.number().min(0).max(8).optional(),
   nameCardId: z.number().min(0),
   finishAchievementNum: z.number().min(0),
-  towerFloorIndex: z.number().min(0).max(12),
-  towerLevelIndex: z.number().min(0).max(3),
-  showAvatarInfoList: z.array(resumedAvatarInfoSchema).max(8),
-  showNameCardIdList: z.array(z.number().min(0)).max(9),
+  towerFloorIndex: z.number().min(0).max(12).optional(),
+  towerLevelIndex: z.number().min(0).max(3).optional(),
+  showAvatarInfoList: z.array(resumedAvatarInfoSchema).max(8).optional(),
+  showNameCardIdList: z.array(z.number().min(0)).max(9).optional(),
   profilePicture: profilePictureSchema,
 });
 

--- a/src/model/internal/genshin/index.ts
+++ b/src/model/internal/genshin/index.ts
@@ -6,7 +6,7 @@ export class GenshinProfile {
   public ttl: number;
   public uid: string;
   public playerInfo: PlayerInfo;
-  public characterInfo: Array<Character>;
+  public characterInfo?: Array<Character>; // Optional
 
   constructor(
     profile: GenshinProfileExternal,
@@ -17,11 +17,16 @@ export class GenshinProfile {
 
     this.playerInfo = new PlayerInfo(profile.playerInfo);
 
-    this.characterInfo = new Array<Character>();
+    if (
+      profile.avatarInfoList !== undefined &&
+      profile.avatarInfoList.length > 0
+    ) {
+      this.characterInfo = new Array<Character>();
 
-    if (profile.avatarInfoList) {
       profile.avatarInfoList.forEach((avatarInfo) => {
-        this.characterInfo.push(new Character(avatarInfo, translator));
+        if (this.characterInfo !== undefined) {
+          this.characterInfo.push(new Character(avatarInfo, translator));
+        }
       });
     }
   }

--- a/src/model/internal/genshin/player-info/index.ts
+++ b/src/model/internal/genshin/player-info/index.ts
@@ -5,9 +5,9 @@ export class PlayerInfo {
   username: string;
   level: number;
   signature: string;
-  worldLevel: number;
+  worldLevel?: number;
   achievementNumber: number;
-  abyssInfo: AbyssInfo;
+  abyssInfo?: AbyssInfo;
 
   constructor(playerInfo: PlayerInfoExternal) {
     this.username = playerInfo.nickname;
@@ -15,9 +15,14 @@ export class PlayerInfo {
     this.signature = playerInfo.signature || "";
     this.worldLevel = playerInfo.worldLevel;
     this.achievementNumber = playerInfo.finishAchievementNum;
-    this.abyssInfo = new AbyssInfo(
-      playerInfo.towerFloorIndex,
-      playerInfo.towerLevelIndex,
-    );
+    if (
+      playerInfo.towerFloorIndex !== undefined &&
+      playerInfo.towerLevelIndex !== undefined
+    ) {
+      this.abyssInfo = new AbyssInfo(
+        playerInfo.towerFloorIndex,
+        playerInfo.towerLevelIndex,
+      );
+    }
   }
 }


### PR DESCRIPTION
Fixed the issue where players without displayed characters would not appear on the database.
In the process, also fixed the same issue but with players without abyss progress or world level.
Also removed the empty array from showing on the exported profile.